### PR TITLE
Data export & backup (#23)

### DIFF
--- a/src/entrypoints/app/main.ts
+++ b/src/entrypoints/app/main.ts
@@ -2,10 +2,14 @@ import { mount } from 'svelte';
 import '../../assets/app.css';
 import App from './App.svelte';
 
-// Dev helpers (fake-data seed/clear) only attach in development builds.
-// Wiping a user's real submissions from prod devtools would be a disaster.
-if (import.meta.env.DEV) {
-  import('../../lib/__dev__/dev-helpers').then((m) => m.attachDevHelpers());
-}
+// Guard side-effects to this page (see popup/main.ts) so this entry can't mount
+// onto popup.html if Vite hoists it into a shared chunk.
+if (window.location.pathname.endsWith('/app.html')) {
+  // Dev helpers (fake-data seed/clear) only attach in development builds.
+  // Wiping a user's real submissions from prod devtools would be a disaster.
+  if (import.meta.env.DEV) {
+    import('../../lib/__dev__/dev-helpers').then((m) => m.attachDevHelpers());
+  }
 
-mount(App, { target: document.getElementById('app')! });
+  mount(App, { target: document.getElementById('app')! });
+}

--- a/src/entrypoints/app/views/EarningsView.svelte
+++ b/src/entrypoints/app/views/EarningsView.svelte
@@ -2077,7 +2077,8 @@
       <div class="rounded-lg border border-base-300 p-3 flex flex-col gap-2">
         <div class="text-sm font-semibold">Submissions → CSV</div>
         <div class="text-xs text-base-content/55 flex-1 leading-snug">
-          A spreadsheet of every submission, in the same format Prolific exports — so it re-imports here cleanly.
+          A spreadsheet of every submission — Prolific-compatible, plus the researcher, institution and rejection
+          details Prolific's own export leaves out. Re-imports here cleanly.
         </div>
         <button
           id="exportSubmissionsBtn"

--- a/src/entrypoints/app/views/EarningsView.svelte
+++ b/src/entrypoints/app/views/EarningsView.svelte
@@ -39,9 +39,30 @@
     type RateStats,
     type GroupAgg,
   } from '../../../lib/earnings';
-  import { formatMoneyFromMajorUnits, formatDurationSeconds, formatSubmissionStatus, normalizeSubmissionStatus } from '../../../lib/format';
+  import { formatMoneyFromMajorUnits, formatDurationSeconds, formatSubmissionStatus, normalizeSubmissionStatus, nowIso } from '../../../lib/format';
   import { parseProlificCsv, type CsvImportResult } from '../../../lib/import-csv';
   import { importSubmissions } from '../../../lib/store';
+  import { browser } from 'wxt/browser';
+  import {
+    submissionsToCsv,
+    dailyRollupsToCsv,
+    groupAggToCsv,
+    forecastToCsv,
+    analyticsToJson,
+    backupDateStamp,
+    validateBackup,
+    summarizeBackup,
+    type AnalyticsBundle,
+    type AnalyticsDatasetKey,
+    type ForecastRow,
+    type BackupFile,
+    type BackupSummary,
+  } from '../../../lib/export-data';
+  import {
+    exportBackup as buildDbBackup,
+    restoreBackup as applyDbRestore,
+    browserStorageAdapter,
+  } from '../../../lib/backup';
   import { scaleBand } from 'd3-scale';
   import { Area, Axis, Bar, Chart, ChartClipPath, Circle, Highlight, Rule, Spline, Svg, Tooltip } from 'layerchart';
 
@@ -842,6 +863,199 @@
     } finally {
       importBusy = false;
     }
+  }
+
+  // ── Export & backup (issue #23) ────────────────────────────
+  const storageAdapter = browserStorageAdapter(browser.storage.local);
+  const appVersion = browser.runtime.getManifest().version;
+
+  let exportError = $state<string | null>(null);
+  let exportBanner = $state<string | null>(null);
+  let exportBusy = $state(false);
+  let bannerTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flashBanner(msg: string) {
+    exportError = null;
+    exportBanner = msg;
+    if (bannerTimer) clearTimeout(bannerTimer);
+    bannerTimer = setTimeout(() => { exportBanner = null; bannerTimer = null; }, 6000);
+  }
+
+  $effect(() => () => { if (bannerTimer) clearTimeout(bannerTimer); });
+
+  /** Trigger a client-side download of in-memory text (no network, no permissions). */
+  function downloadFile(filename: string, content: string, mime: string) {
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+
+  const nowStamp = () => backupDateStamp(nowIso());
+
+  function exportSubmissionsCsv() {
+    if (!submissions.length) return;
+    try {
+      // Export the raw stored records (not currency-converted) so the file
+      // round-trips cleanly back through the CSV importer.
+      const csv = submissionsToCsv(submissions);
+      downloadFile(`prolific-submissions-${nowStamp()}.csv`, csv, 'text/csv;charset=utf-8');
+      flashBanner(`Exported ${submissions.length} submission${submissions.length === 1 ? '' : 's'} to CSV.`);
+    } catch (err) {
+      exportError = err instanceof Error ? err.message : 'Export failed';
+    }
+  }
+
+  // Configurable analytics export.
+  type AnalyticsFormat = 'csv' | 'json';
+  const analyticsDatasets: { key: AnalyticsDatasetKey; label: string }[] = [
+    { key: 'daily', label: 'Daily totals' },
+    { key: 'researchers', label: 'By researcher' },
+    { key: 'studies', label: 'By study' },
+    { key: 'forecast', label: 'Forecast' },
+  ];
+  let analyticsOpen = $state(false);
+  let analyticsFormat = $state<AnalyticsFormat>('csv');
+  let analyticsSel = $state<Record<AnalyticsDatasetKey, boolean>>({
+    daily: true, researchers: true, studies: true, forecast: true,
+  });
+
+  const forecastExportRows: ForecastRow[] = $derived.by(() => {
+    if (!currency || !forecastWeekdayStats?.ready) return [];
+    const start = addLocalDays(startOfLocalDay(now), 1);
+    return forecastDaily(forecastWeekdayStats.stats, start, 14).map((p) => ({
+      date_key: p.date_key, median: p.median, p25: p.p25, p75: p.p75,
+    }));
+  });
+  const forecastAvailable = $derived(forecastExportRows.length > 0);
+
+  function isDatasetSelectable(key: AnalyticsDatasetKey): boolean {
+    return key !== 'forecast' || forecastAvailable;
+  }
+  const anyAnalyticsSelected = $derived(
+    analyticsDatasets.some((d) => analyticsSel[d.key] && isDatasetSelectable(d.key)),
+  );
+
+  function toggleAnalyticsDataset(key: AnalyticsDatasetKey, checked: boolean) {
+    analyticsSel = { ...analyticsSel, [key]: checked };
+  }
+
+  function exportAnalytics() {
+    if (!anyAnalyticsSelected) return;
+    const stamp = nowStamp();
+    const sel = analyticsSel;
+    try {
+      if (analyticsFormat === 'json') {
+        const bundle: AnalyticsBundle = { currency, generated_at: nowIso() };
+        if (sel.daily) bundle.daily = rangeRollups;
+        if (sel.researchers) bundle.researchers = fullResearcherBoard;
+        if (sel.studies) bundle.studies = fullStudyBoard;
+        if (sel.forecast && forecastAvailable) bundle.forecast = forecastExportRows;
+        downloadFile(`prolific-analytics-${stamp}.json`, analyticsToJson(bundle), 'application/json');
+      } else {
+        if (sel.daily) downloadFile(`prolific-daily-${stamp}.csv`, dailyRollupsToCsv(rangeRollups), 'text/csv;charset=utf-8');
+        if (sel.researchers) downloadFile(`prolific-researchers-${stamp}.csv`, groupAggToCsv(fullResearcherBoard, 'Researcher'), 'text/csv;charset=utf-8');
+        if (sel.studies) downloadFile(`prolific-studies-${stamp}.csv`, groupAggToCsv(fullStudyBoard, 'Study'), 'text/csv;charset=utf-8');
+        if (sel.forecast && forecastAvailable) downloadFile(`prolific-forecast-${stamp}.csv`, forecastToCsv(forecastExportRows, currency), 'text/csv;charset=utf-8');
+      }
+      analyticsOpen = false;
+      flashBanner(`Analytics exported (${range.label}).`);
+    } catch (err) {
+      exportError = err instanceof Error ? err.message : 'Export failed';
+    }
+  }
+
+  async function backupAll() {
+    exportBusy = true;
+    exportError = null;
+    try {
+      const backup = await buildDbBackup(storageAdapter, appVersion);
+      downloadFile(`prolific-pulse-backup-${backupDateStamp(backup.exported_at)}.json`, JSON.stringify(backup), 'application/json');
+      const summary = summarizeBackup(backup);
+      flashBanner(`Backed up ${summary.tableTotal} record${summary.tableTotal === 1 ? '' : 's'} and ${summary.settingsCount} setting${summary.settingsCount === 1 ? '' : 's'}.`);
+    } catch (err) {
+      exportError = err instanceof Error ? err.message : 'Backup failed';
+    } finally {
+      exportBusy = false;
+    }
+  }
+
+  // ── Restore ────────────────────────────────────────────────
+  const TABLE_LABELS: Record<string, string> = {
+    submissions: 'submissions',
+    studiesLatest: 'live studies',
+    studiesHistory: 'study-history rows',
+    studiesActiveSnapshot: 'active studies',
+    studyAvailabilityEvents: 'availability events',
+    researchers: 'researchers',
+    serviceState: 'service rows',
+    observationLog: 'observation points',
+  };
+  function tableLabel(name: string): string {
+    return TABLE_LABELS[name] ?? name;
+  }
+
+  let restoreInput: HTMLInputElement;
+  // Kept out of $state — Svelte Proxies don't survive IndexedDB's structured clone.
+  let pendingBackup: BackupFile | null = null;
+  let restorePending = $state<{ filename: string; summary: BackupSummary } | null>(null);
+  let restoreIncludeSettings = $state(true);
+  let restoreBusy = $state(false);
+  let restoreError = $state<string | null>(null);
+
+  async function handleRestoreFile(e: Event) {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (restoreInput) restoreInput.value = '';
+    if (!file) return;
+    restoreError = null;
+    exportBanner = null;
+    try {
+      const res = validateBackup(await file.text());
+      if (!res.ok) { restoreError = res.error; return; }
+      pendingBackup = res.backup;
+      restorePending = { filename: file.name, summary: summarizeBackup(res.backup) };
+    } catch (err) {
+      restoreError = err instanceof Error ? err.message : 'Failed to read file';
+    }
+  }
+
+  function cancelRestore() {
+    restorePending = null;
+    pendingBackup = null;
+    restoreError = null;
+  }
+
+  async function confirmRestore() {
+    if (!pendingBackup) return;
+    restoreBusy = true;
+    restoreError = null;
+    let summary;
+    try {
+      summary = await applyDbRestore(pendingBackup, storageAdapter, { includeSettings: restoreIncludeSettings });
+    } catch (err) {
+      restoreError = err instanceof Error ? err.message : 'Restore failed';
+      restoreBusy = false;
+      return;
+    }
+    // The DB is committed at this point — report success before any best-effort
+    // follow-up so a hiccup there can't surface a misleading "Restore failed".
+    restorePending = null;
+    pendingBackup = null;
+    restoreBusy = false;
+    const settingsNote = summary.settingsRestored
+      ? ' Restored settings finish applying to alerts once the extension next restarts.'
+      : '';
+    flashBanner(`Restored ${summary.rowsRestored} record${summary.rowsRestored === 1 ? '' : 's'}.${settingsNote}`);
+    try {
+      await onReloadSubmissions();
+      // Nudge any open popup/other view to re-read the restored DB.
+      await browser.runtime.sendMessage({ action: 'dashboardUpdated' });
+    } catch { /* best-effort refresh; restore already succeeded */ }
   }
 </script>
 
@@ -1830,4 +2044,192 @@
       {/if}
     </section>
   {/if}
+
+  <!-- Backup & export (issue #23) -->
+  <section id="dataExportCard" class="rounded-lg border border-base-300 bg-base-100 p-4 space-y-4">
+    <div>
+      <h2 class="font-semibold">Backup &amp; export</h2>
+      <p class="text-sm text-base-content/60 mt-0.5">
+        Download your data or move it to another browser. Everything stays on your device — nothing is uploaded.
+      </p>
+    </div>
+
+    {#if exportBanner}
+      <div class="rounded border border-emerald-500/50 bg-emerald-500/10 p-3 text-sm flex items-center gap-2" id="exportBanner">
+        <span class="text-emerald-500 font-bold">✓</span>
+        <span class="flex-1">{exportBanner}</span>
+        <button type="button" class="btn btn-ghost btn-xs" onclick={() => (exportBanner = null)}>Dismiss</button>
+      </div>
+    {/if}
+    {#if exportError}
+      <div class="rounded border border-rose-500/50 bg-rose-500/10 p-3 text-sm flex items-start gap-2">
+        <span class="text-rose-500 font-bold">✕</span>
+        <div class="flex-1">
+          <div class="font-semibold">Something went wrong</div>
+          <div class="text-xs mt-0.5 text-base-content/70">{exportError}</div>
+        </div>
+        <button type="button" class="btn btn-ghost btn-xs" onclick={() => (exportError = null)}>Dismiss</button>
+      </div>
+    {/if}
+
+    <div class="grid gap-3 md:grid-cols-3">
+      <!-- Submissions CSV -->
+      <div class="rounded-lg border border-base-300 p-3 flex flex-col gap-2">
+        <div class="text-sm font-semibold">Submissions → CSV</div>
+        <div class="text-xs text-base-content/55 flex-1 leading-snug">
+          A spreadsheet of every submission, in the same format Prolific exports — so it re-imports here cleanly.
+        </div>
+        <button
+          id="exportSubmissionsBtn"
+          type="button"
+          class="btn btn-sm btn-outline gap-1.5"
+          disabled={submissions.length === 0}
+          onclick={exportSubmissionsCsv}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          Download CSV
+        </button>
+      </div>
+
+      <!-- Analytics (configurable) -->
+      <div class="rounded-lg border border-base-300 p-3 flex flex-col gap-2">
+        <div class="text-sm font-semibold">Analytics → CSV / JSON</div>
+        <div class="text-xs text-base-content/55 flex-1 leading-snug">
+          Daily totals, per-researcher and per-study summaries, and your forecast — pick what you need for spreadsheets or taxes.
+        </div>
+        <button
+          id="exportAnalyticsBtn"
+          type="button"
+          class="btn btn-sm btn-outline gap-1.5"
+          disabled={submissions.length === 0}
+          onclick={() => (analyticsOpen = !analyticsOpen)}
+          aria-expanded={analyticsOpen}
+        >
+          Choose &amp; export
+          <span class="inline-block transition-transform text-[9px]" class:rotate-90={analyticsOpen}>▶</span>
+        </button>
+      </div>
+
+      <!-- Full backup + restore -->
+      <div class="rounded-lg border border-base-300 p-3 flex flex-col gap-2">
+        <div class="text-sm font-semibold">Full backup → JSON</div>
+        <div class="text-xs text-base-content/55 flex-1 leading-snug">
+          A complete snapshot — studies, submissions, researchers, and settings — to move machines or recover after a reset.
+        </div>
+        <div class="flex gap-2">
+          <button
+            id="backupAllBtn"
+            type="button"
+            class="btn btn-sm btn-primary gap-1.5 flex-1"
+            disabled={exportBusy}
+            onclick={backupAll}
+          >
+            {exportBusy ? 'Backing up…' : 'Back up all'}
+          </button>
+          <button
+            id="restoreBtn"
+            type="button"
+            class="btn btn-sm btn-outline flex-1"
+            onclick={() => restoreInput?.click()}
+          >
+            Restore…
+          </button>
+        </div>
+        <input bind:this={restoreInput} type="file" accept=".json,application/json" class="hidden" onchange={handleRestoreFile} />
+      </div>
+    </div>
+
+    {#if analyticsOpen}
+      <div id="analyticsExportPanel" class="rounded-lg border border-primary/30 bg-primary/5 p-3 space-y-2.5">
+        <div class="text-xs font-semibold text-base-content/70">Include · <span class="font-normal text-base-content/55">{range.label}</span></div>
+        <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+          {#each analyticsDatasets as ds (ds.key)}
+            {@const selectable = isDatasetSelectable(ds.key)}
+            <label class="flex items-center gap-1.5 text-sm cursor-pointer" class:opacity-40={!selectable}>
+              <input
+                type="checkbox"
+                class="checkbox checkbox-sm"
+                data-analytics-key={ds.key}
+                checked={analyticsSel[ds.key] && selectable}
+                disabled={!selectable}
+                onchange={(e) => toggleAnalyticsDataset(ds.key, (e.target as HTMLInputElement).checked)}
+              />
+              {ds.label}{ds.key === 'forecast' && !selectable ? ' (needs more history)' : ''}
+            </label>
+          {/each}
+        </div>
+        <div class="flex items-center gap-4 flex-wrap">
+          <span class="text-xs font-semibold text-base-content/70">Format</span>
+          <label class="flex items-center gap-1.5 text-sm cursor-pointer">
+            <input type="radio" name="analyticsFormat" class="radio radio-sm" checked={analyticsFormat === 'csv'} onchange={() => (analyticsFormat = 'csv')} />
+            CSV
+          </label>
+          <label class="flex items-center gap-1.5 text-sm cursor-pointer">
+            <input type="radio" name="analyticsFormat" class="radio radio-sm" checked={analyticsFormat === 'json'} onchange={() => (analyticsFormat = 'json')} />
+            JSON
+          </label>
+          <button
+            id="analyticsDownloadBtn"
+            type="button"
+            class="btn btn-sm btn-primary ml-auto"
+            disabled={!anyAnalyticsSelected}
+            onclick={exportAnalytics}
+          >
+            Download
+          </button>
+        </div>
+        {#if analyticsFormat === 'csv'}
+          <div class="text-[11px] text-base-content/45">CSV downloads one file per selected dataset.</div>
+        {/if}
+      </div>
+    {/if}
+
+    {#if restorePending}
+      <div id="restoreConfirm" class="rounded-lg border border-amber-500/50 bg-amber-500/10 p-4 text-sm space-y-2.5">
+        <div class="font-semibold text-base">
+          Restore from <span class="font-mono text-[13px] text-base-content/70">{restorePending.filename}</span>?
+        </div>
+        <div class="text-xs text-base-content/75">This <strong>replaces</strong> your current local data with the backup's:</div>
+        {#if restorePending.summary.tables.length > 0}
+          <ul class="text-xs text-base-content/70 grid grid-cols-2 gap-x-4 gap-y-0.5">
+            {#each restorePending.summary.tables as t (t.name)}
+              <li>• {t.count} {tableLabel(t.name)}</li>
+            {/each}
+          </ul>
+        {/if}
+        {#if restorePending.summary.settingsCount > 0}
+          <label class="flex items-center gap-1.5 text-xs cursor-pointer">
+            <input
+              type="checkbox"
+              class="checkbox checkbox-xs"
+              checked={restoreIncludeSettings}
+              onchange={(e) => (restoreIncludeSettings = (e.target as HTMLInputElement).checked)}
+            />
+            Also restore settings &amp; preferences ({restorePending.summary.settingsCount})
+          </label>
+        {/if}
+        <div class="text-[11px] text-base-content/55 leading-snug">
+          Your current data is overwritten and can't be recovered unless you've backed it up first.
+        </div>
+        {#if restoreError}
+          <div class="text-xs text-rose-500">{restoreError}</div>
+        {/if}
+        <div class="flex gap-2 justify-end">
+          <button type="button" class="btn btn-ghost btn-sm" onclick={cancelRestore} disabled={restoreBusy}>Cancel</button>
+          <button id="confirmRestoreBtn" type="button" class="btn btn-warning btn-sm" onclick={confirmRestore} disabled={restoreBusy}>
+            {restoreBusy ? 'Restoring…' : 'Replace my data'}
+          </button>
+        </div>
+      </div>
+    {:else if restoreError}
+      <div class="rounded border border-rose-500/50 bg-rose-500/10 p-3 text-sm flex items-start gap-2">
+        <span class="text-rose-500 font-bold">✕</span>
+        <div class="flex-1">
+          <div class="font-semibold">Couldn't read that backup</div>
+          <div class="text-xs mt-0.5 text-base-content/70">{restoreError}</div>
+        </div>
+        <button type="button" class="btn btn-ghost btn-xs" onclick={() => (restoreError = null)}>Dismiss</button>
+      </div>
+    {/if}
+  </section>
 </div>

--- a/src/entrypoints/popup/main.ts
+++ b/src/entrypoints/popup/main.ts
@@ -2,9 +2,15 @@ import { mount } from 'svelte';
 import '../../assets/app.css';
 import App from './App.svelte';
 
-if (import.meta.env.DEV) {
-  import('../../lib/__dev__/dev-helpers').then((m) => m.attachDevHelpers());
-}
+// Guard side-effects to this page. Vite can hoist an entry module into a chunk
+// another page loads (e.g. app.html dynamically imports dev-helpers, which may
+// pull this chunk in) — without the guard the popup would mount a second time
+// onto app.html. Keying on the pathname keeps each entry to its own page.
+if (window.location.pathname.endsWith('/popup.html')) {
+  if (import.meta.env.DEV) {
+    import('../../lib/__dev__/dev-helpers').then((m) => m.attachDevHelpers());
+  }
 
-document.body.classList.add('no-scroll');
-mount(App, { target: document.getElementById('app')! });
+  document.body.classList.add('no-scroll');
+  mount(App, { target: document.getElementById('app')! });
+}

--- a/src/eslint.config.js
+++ b/src/eslint.config.js
@@ -20,6 +20,8 @@ export default ts.config(
         clearInterval: 'readonly',
         fetch: 'readonly',
         atob: 'readonly',
+        Blob: 'readonly',
+        URL: 'readonly',
         AudioContext: 'readonly',
         AudioBuffer: 'readonly',
         AudioBufferSourceNode: 'readonly',

--- a/src/lib/__dev__/dev-helpers.ts
+++ b/src/lib/__dev__/dev-helpers.ts
@@ -1,5 +1,7 @@
 import { seedFakeSubmissions, clearFakeSubmissions } from './fake-submissions';
 import { seedFakeStudies, seedSparseStudies, clearFakeStudies, wipeStudyData, seedSyncState, seedMutes, clearMutes } from './fake-studies';
+import { devExportBackup, devRestoreBackup, devSeedResearchers, devCountTables } from './fake-backup';
+import type { RestoreSummary } from '../backup';
 
 declare global {
   interface Window {
@@ -13,6 +15,10 @@ declare global {
       seedSyncState: (patch?: Record<string, unknown>) => Promise<void>;
       seedMutes: () => Promise<number>;
       clearMutes: () => Promise<void>;
+      exportBackup: () => Promise<string>;
+      restoreBackup: (json: string) => Promise<RestoreSummary>;
+      seedResearchers: (count?: number) => Promise<number>;
+      countTables: () => Promise<Record<string, number>>;
     };
   }
 }
@@ -29,5 +35,9 @@ export function attachDevHelpers(): void {
     seedSyncState,
     seedMutes,
     clearMutes,
+    exportBackup: devExportBackup,
+    restoreBackup: devRestoreBackup,
+    seedResearchers: devSeedResearchers,
+    countTables: devCountTables,
   };
 }

--- a/src/lib/__dev__/fake-backup.ts
+++ b/src/lib/__dev__/fake-backup.ts
@@ -1,0 +1,50 @@
+// Dev-only helpers for exercising the export/backup feature (issue #23) in e2e.
+// Attached to window.__ppDev in dev builds only — see dev-helpers.ts.
+import { browser } from 'wxt/browser';
+import { db } from '../db';
+import type { ResearcherRecord } from '../db';
+import { exportBackup, restoreBackup, browserStorageAdapter, type RestoreSummary } from '../backup';
+import { validateBackup } from '../export-data';
+
+function adapter() {
+  return browserStorageAdapter(browser.storage.local);
+}
+
+/** Return the real backup JSON string (same path the "Back up all" button takes). */
+export async function devExportBackup(): Promise<string> {
+  const version = browser.runtime.getManifest().version;
+  const backup = await exportBackup(adapter(), version);
+  return JSON.stringify(backup);
+}
+
+/** Validate + restore a backup JSON string, returning the restore summary. */
+export async function devRestoreBackup(json: string): Promise<RestoreSummary> {
+  const res = validateBackup(json);
+  if (!res.ok) throw new Error(res.error);
+  return restoreBackup(res.backup, adapter());
+}
+
+/** Seed synthetic researcher rows so a backup has cross-table content. */
+export async function devSeedResearchers(count = 5): Promise<number> {
+  const rows: ResearcherRecord[] = [];
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      id: `dev-researcher-${i}`,
+      name: `Dr Synthetic ${i}`,
+      country: ['UK', 'US', 'DE', 'CA'][i % 4],
+      first_seen_at: '2026-01-01T00:00:00.000Z',
+      last_seen_at: '2026-06-01T00:00:00.000Z',
+      study_count: (i % 5) + 1,
+      submission_count: (i % 9) + 1,
+    });
+  }
+  await db.researchers.bulkPut(rows);
+  return rows.length;
+}
+
+/** Row counts per table — lets e2e assert a restore round-trip deterministically. */
+export async function devCountTables(): Promise<Record<string, number>> {
+  const out: Record<string, number> = {};
+  for (const table of db.tables) out[table.name] = await table.count();
+  return out;
+}

--- a/src/lib/__tests__/backup.test.ts
+++ b/src/lib/__tests__/backup.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { db } from '../db';
+import type { SubmissionRecord, ResearcherRecord } from '../db';
+import {
+  dumpTables,
+  exportBackup,
+  restoreBackup,
+  browserStorageAdapter,
+  type BackupStorage,
+} from '../backup';
+import { validateBackup, BACKUP_FORMAT } from '../export-data';
+
+/** In-memory stand-in for browser.storage.local. */
+function memStorage(initial: Record<string, unknown> = {}): BackupStorage & { data: Record<string, unknown> } {
+  const data: Record<string, unknown> = { ...initial };
+  return {
+    data,
+    getAll: async () => ({ ...data }),
+    setAll: async (items) => {
+      Object.assign(data, items);
+    },
+  };
+}
+
+function sub(id: string): SubmissionRecord {
+  return {
+    submission_id: id,
+    study_id: `study-${id}`,
+    study_name: `Study ${id}`,
+    participant_id: 'p1',
+    status: 'APPROVED',
+    phase: 'submitted',
+    observed_at: '2026-03-25T16:10:53.160Z',
+    updated_at: '2026-03-25T16:10:53.160Z',
+    payload: { submission_reward: { amount: 500, currency: 'USD' } },
+  };
+}
+
+function researcher(id: string): ResearcherRecord {
+  return {
+    id,
+    name: `Researcher ${id}`,
+    country: 'UK',
+    first_seen_at: '2026-01-01T00:00:00.000Z',
+    last_seen_at: '2026-03-01T00:00:00.000Z',
+    study_count: 2,
+    submission_count: 5,
+  };
+}
+
+async function wipe() {
+  await Promise.all(db.tables.map((t) => t.clear()));
+}
+
+describe('backup export/restore round-trip (fake-indexeddb)', () => {
+  beforeEach(wipe);
+
+  it('dumps every table', async () => {
+    await db.submissions.bulkPut([sub('a'), sub('b')]);
+    await db.researchers.bulkPut([researcher('r1')]);
+    const tables = await dumpTables();
+    expect(Object.keys(tables).sort()).toEqual(db.tables.map((t) => t.name).sort());
+    expect(tables.submissions).toHaveLength(2);
+    expect(tables.researchers).toHaveLength(1);
+  });
+
+  it('exports a valid backup including settings', async () => {
+    await db.submissions.bulkPut([sub('a')]);
+    const storage = memStorage({ theme: 'dark', earningsPrefs: { primary_currency: 'GBP' } });
+    const backup = await exportBackup(storage, '1.3.1');
+    expect(backup.format).toBe(BACKUP_FORMAT);
+    expect(backup.settings.theme).toBe('dark');
+    expect(validateBackup(JSON.stringify(backup)).ok).toBe(true);
+  });
+
+  it('restores DB + settings, replacing existing data', async () => {
+    // Seed original data + settings, export.
+    await db.submissions.bulkPut([sub('a'), sub('b'), sub('c')]);
+    await db.researchers.bulkPut([researcher('r1'), researcher('r2')]);
+    const storage = memStorage({ theme: 'dark', mutes: ['x'] });
+    const backup = await exportBackup(storage, '1.3.1');
+
+    // Mutate the DB + settings after the backup, and add a runtime-only key
+    // (e.g. auth token) that isn't in the backup.
+    await wipe();
+    await db.submissions.bulkPut([sub('z')]);
+    storage.data.theme = 'light';
+    delete storage.data.mutes;
+    storage.data.syncState = { token_ok: true };
+
+    // Restore.
+    const summary = await restoreBackup(backup, storage);
+    const subs = await db.submissions.toArray();
+    const researchers = await db.researchers.toArray();
+    expect(subs.map((s) => s.submission_id).sort()).toEqual(['a', 'b', 'c']);
+    expect(researchers).toHaveLength(2);
+    expect(subs.find((s) => s.submission_id === 'z')).toBeUndefined();
+    expect(storage.data.theme).toBe('dark');
+    expect(storage.data.mutes).toEqual(['x']);
+    // Merge (not clear) preserves runtime-only keys the backup didn't carry.
+    expect(storage.data.syncState).toEqual({ token_ok: true });
+    expect(summary.rowsRestored).toBe(5);
+    expect(summary.settingsRestored).toBe(2);
+  });
+
+  it('honours includeSettings:false on restore (DB only, settings untouched)', async () => {
+    await db.submissions.bulkPut([sub('a')]);
+    const storage = memStorage({ theme: 'dark' });
+    const backup = await exportBackup(storage, '1.3.1');
+    storage.data.theme = 'light';
+    await restoreBackup(backup, storage, { includeSettings: false });
+    expect(storage.data.theme).toBe('light');
+  });
+
+  it('skips unknown tables in a backup rather than failing', async () => {
+    await db.submissions.bulkPut([sub('a')]);
+    const storage = memStorage();
+    const backup = await exportBackup(storage, '1.3.1');
+    backup.tables.someFutureTable = [{ x: 1 }];
+    const summary = await restoreBackup(backup, storage);
+    expect(summary.skippedUnknownTables).toContain('someFutureTable');
+    // Known data still restored.
+    expect(await db.submissions.count()).toBe(1);
+  });
+
+  it('leaves tables absent from the backup untouched (no silent wipe)', async () => {
+    await db.submissions.bulkPut([sub('a')]);
+    await db.researchers.bulkPut([researcher('r1')]);
+    const storage = memStorage();
+    const backup = await exportBackup(storage, '1.3.1');
+    // Simulate an older/partial backup that predates the researchers table, then
+    // add a live row. Restore must preserve it rather than wipe it.
+    delete backup.tables.researchers;
+    await db.researchers.bulkPut([researcher('r2')]);
+    const summary = await restoreBackup(backup, storage);
+    const ids = (await db.researchers.toArray()).map((r) => r.id).sort();
+    expect(ids).toEqual(['r1', 'r2']);
+    expect(summary.tablesRestored).toBe(db.tables.length - 1);
+  });
+
+  it('browserStorageAdapter maps to a storage.local-shaped object', async () => {
+    const store: Record<string, unknown> = { a: 1 };
+    const adapter = browserStorageAdapter({
+      get: async () => ({ ...store }),
+      set: async (items) => {
+        Object.assign(store, items);
+      },
+    });
+    expect(await adapter.getAll()).toEqual({ a: 1 });
+    await adapter.setAll({ b: 2 });
+    expect(store).toEqual({ a: 1, b: 2 });
+  });
+});

--- a/src/lib/__tests__/export-data.test.ts
+++ b/src/lib/__tests__/export-data.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect } from 'vitest';
+import {
+  csvField,
+  toCsv,
+  formatMoneyCell,
+  formatCsvTimestamp,
+  submissionsToCsv,
+  submissionToRow,
+  dailyRollupsToCsv,
+  groupAggToCsv,
+  forecastToCsv,
+  analyticsToJson,
+  buildBackup,
+  validateBackup,
+  summarizeBackup,
+  backupDateStamp,
+  BACKUP_FORMAT,
+} from '../export-data';
+import { parseCsv, parseMoneyCell, parseCsvTimestamp, parseProlificCsv } from '../import-csv';
+import type { SubmissionRecord } from '../db';
+import type { DailyRollup, GroupAgg } from '../earnings';
+
+// ── CSV serialiser ────────────────────────────────────────────
+
+describe('csvField', () => {
+  it('leaves simple values unquoted', () => {
+    expect(csvField('hello')).toBe('hello');
+    expect(csvField(42)).toBe('42');
+    expect(csvField('')).toBe('');
+    expect(csvField(null)).toBe('');
+    expect(csvField(undefined)).toBe('');
+  });
+
+  it('quotes and escapes fields with delimiters, quotes, or newlines', () => {
+    expect(csvField('a,b')).toBe('"a,b"');
+    expect(csvField('say "hi"')).toBe('"say ""hi"""');
+    expect(csvField('line1\nline2')).toBe('"line1\nline2"');
+  });
+});
+
+describe('toCsv ↔ parseCsv round-trip', () => {
+  it('survives a round-trip through the importer tokeniser', () => {
+    const rows = [
+      ['Study', 'Reward', 'Note'],
+      ['Simple', '$7.50', 'ok'],
+      ['Has, comma', '£2.00', 'quote " inside'],
+      ['New\nline', '€1.00', ''],
+    ];
+    const parsed = parseCsv(toCsv(rows));
+    expect(parsed).toEqual(rows);
+  });
+});
+
+// ── money / timestamp inverse of import-csv ───────────────────
+
+describe('formatMoneyCell ↔ parseMoneyCell', () => {
+  const cases: [number, string][] = [
+    [750, 'USD'],
+    [267, 'GBP'],
+    [420, 'EUR'],
+    [1000, 'CAD'],
+    [525, 'AUD'],
+    [5025, 'SEK'], // ambiguous symbol → falls back to `amount CODE`
+    [9999, 'NOK'],
+    [1, 'JPY'],
+    [123456, 'BRL'],
+  ];
+  for (const [minor, currency] of cases) {
+    it(`round-trips ${minor} ${currency}`, () => {
+      const cell = formatMoneyCell(minor, currency);
+      expect(parseMoneyCell(cell)).toEqual({ amount_minor: minor, currency });
+    });
+  }
+
+  it('does not use the ambiguous kr symbol for SEK/NOK/DKK', () => {
+    expect(formatMoneyCell(5000, 'NOK')).toBe('50.00 NOK');
+    expect(formatMoneyCell(5000, 'DKK')).toBe('50.00 DKK');
+  });
+});
+
+describe('formatCsvTimestamp ↔ parseCsvTimestamp', () => {
+  it('round-trips an ISO timestamp through the importer parser', () => {
+    const iso = '2026-03-25T16:10:53.160Z';
+    const cell = formatCsvTimestamp(iso);
+    expect(cell).toBe('2026-03-25 16:10:53.160000');
+    expect(parseCsvTimestamp(cell)).toBe(iso);
+  });
+
+  it('handles midnight and single-digit fields with padding', () => {
+    const iso = '2026-01-05T04:03:02.000Z';
+    expect(parseCsvTimestamp(formatCsvTimestamp(iso))).toBe(iso);
+  });
+
+  it('returns empty string for missing/invalid input', () => {
+    expect(formatCsvTimestamp('')).toBe('');
+    expect(formatCsvTimestamp(null)).toBe('');
+    expect(formatCsvTimestamp('not-a-date')).toBe('');
+  });
+});
+
+// ── submissions → CSV round-trip through the real importer ────
+
+function makeRecord(overrides: Partial<SubmissionRecord> & { payload?: Record<string, unknown> } = {}): SubmissionRecord {
+  return {
+    submission_id: 'csv:ABC123',
+    study_id: 'csv:my-study',
+    study_name: 'My Study',
+    participant_id: 'csv-import',
+    status: 'APPROVED',
+    phase: 'submitted',
+    observed_at: '2026-03-25T16:10:53.160Z',
+    updated_at: '2026-03-25T16:10:53.160Z',
+    payload: {
+      study: { name: 'My Study' },
+      _source: 'csv-import',
+      submission_reward: { amount: 750, currency: 'USD' },
+      started_at: '2026-03-25T15:40:00.000Z',
+      completed_at: '2026-03-25T16:10:53.160Z',
+      completion_code: 'ABC123',
+    },
+    ...overrides,
+  };
+}
+
+/** Strip fields the importer regenerates from wall-clock time so records compare cleanly. */
+function stable(r: SubmissionRecord) {
+  const { updated_at: _u, ...rest } = r;
+  return rest;
+}
+
+describe('submissionsToCsv round-trips through parseProlificCsv', () => {
+  it('preserves an approved submission with reward, bonus, and both timestamps', () => {
+    const original = makeRecord({
+      payload: {
+        study: { name: 'Bonus Study' },
+        _source: 'csv-import',
+        submission_reward: { amount: 500, currency: 'GBP' },
+        bonus_payments: [{ amount: 150, currency: 'GBP' }],
+        started_at: '2026-03-25T15:40:00.000Z',
+        completed_at: '2026-03-25T16:10:53.160Z',
+        completion_code: 'BON999',
+      },
+      submission_id: 'csv:BON999',
+      study_id: 'csv:bonus-study',
+      study_name: 'Bonus Study',
+      status: 'APPROVED',
+    });
+    const csv = submissionsToCsv([original]);
+    const reimported = parseProlificCsv(csv);
+    expect(reimported.records).toHaveLength(1);
+    expect(stable(reimported.records[0])).toEqual(stable(original));
+  });
+
+  it('preserves a RETURNED submission (returned_at ↔ Completed at column)', () => {
+    const original = makeRecord({
+      status: 'RETURNED',
+      submission_id: 'csv:RET1',
+      study_id: 'csv:returned-study',
+      study_name: 'Returned Study',
+      observed_at: '2026-03-25T16:10:53.160Z',
+      payload: {
+        study: { name: 'Returned Study' },
+        _source: 'csv-import',
+        submission_reward: { amount: 300, currency: 'EUR' },
+        started_at: '2026-03-25T15:40:00.000Z',
+        returned_at: '2026-03-25T16:10:53.160Z',
+        completion_code: 'RET1',
+      },
+    });
+    const reimported = parseProlificCsv(submissionsToCsv([original]));
+    expect(reimported.records).toHaveLength(1);
+    expect(stable(reimported.records[0])).toEqual(stable(original));
+  });
+
+  it('round-trips a whole CSV: parse → export → parse is a fixed point', () => {
+    const csv = [
+      'Study,Reward,Bonus,Started at,Completed at,Completion code,Status',
+      'Study A,$7.50,,2026-03-25 15:40:00.000000,2026-03-25 16:10:53.160000,AAA111,APPROVED',
+      'Study B,£2.00,£0.50,2026-03-24 10:00:00.000000,2026-03-24 10:30:00.000000,BBB222,AWAITING REVIEW',
+      'Study C,€3.00,,2026-03-23 09:00:00.000000,2026-03-23 09:20:00.000000,CCC333,RETURNED',
+    ].join('\n');
+    const first = parseProlificCsv(csv).records;
+    const second = parseProlificCsv(submissionsToCsv(first)).records;
+    expect(second.map(stable)).toEqual(first.map(stable));
+  });
+
+  it('emits a header even with no records', () => {
+    const csv = submissionsToCsv([]);
+    expect(csv.split('\r\n')[0]).toContain('Study');
+    expect(parseProlificCsv(csv).records).toHaveLength(0);
+  });
+
+  it('omits a zero bonus', () => {
+    const row = submissionToRow(
+      makeRecord({ payload: { ...makeRecord().payload, bonus_payments: [{ amount: 0, currency: 'USD' }] } }),
+    );
+    // Bonus column (index 4) should be blank.
+    expect(row[4]).toBe('');
+  });
+
+  // ── Adversarial: hostile study names + degenerate rows ──────
+  it('round-trips study names containing commas, quotes, and newlines', () => {
+    const nasty = 'Weird, "Quoted"\nName';
+    const original = makeRecord({
+      study_name: nasty,
+      submission_id: 'csv:NASTY1',
+      study_id: `csv:${'weird-quoted-name'}`,
+      observed_at: '2026-02-01T10:20:00.000Z', // importer derives this from completed_at
+      payload: {
+        study: { name: nasty },
+        _source: 'csv-import',
+        submission_reward: { amount: 250, currency: 'GBP' },
+        started_at: '2026-02-01T10:00:00.000Z',
+        completed_at: '2026-02-01T10:20:00.000Z',
+        completion_code: 'NASTY1',
+      },
+    });
+    const reimported = parseProlificCsv(submissionsToCsv([original]));
+    expect(reimported.records).toHaveLength(1);
+    expect(reimported.records[0].study_name).toBe(nasty);
+    expect(stable(reimported.records[0])).toEqual(stable(original));
+  });
+
+  it('exports a submission with no reward and no bonus without crashing', () => {
+    const row = submissionToRow(
+      makeRecord({
+        payload: {
+          study: { name: 'No Reward' },
+          _source: 'csv-import',
+          started_at: '2026-02-01T10:00:00.000Z',
+          completed_at: '2026-02-01T10:05:00.000Z',
+          completion_code: 'NR1',
+        },
+      }),
+    );
+    expect(row[3]).toBe(''); // reward blank
+    expect(row[4]).toBe(''); // bonus blank
+  });
+
+  // ── Native (live-API) payload shape — different field names than CSV ──
+  // Live submissions store `study_code` + `submission_bonuses`; CSV-imported
+  // ones store `completion_code` + `bonus_payments`. Export must read both.
+  function makeNativeRecord(): SubmissionRecord {
+    return {
+      submission_id: 'sub-native-1',
+      study_id: 'study-abc',
+      study_name: 'Native Study',
+      participant_id: 'real-participant',
+      status: 'APPROVED',
+      phase: 'submitted',
+      observed_at: '2026-04-01T12:00:00.000Z',
+      updated_at: '2026-04-01T12:00:00.000Z',
+      payload: {
+        study: { name: 'Native Study' },
+        study_code: 'NATIVE99',
+        submission_reward: { amount: 500, currency: 'GBP' },
+        submission_bonuses: [
+          { amount: 100, currency: 'GBP' },
+          { amount: 50, currency: 'GBP' },
+        ],
+        started_at: '2026-04-01T11:30:00.000Z',
+        completed_at: '2026-04-01T12:00:00.000Z',
+      },
+    };
+  }
+
+  it('exports the completion code from a native `study_code` field', () => {
+    const row = submissionToRow(makeNativeRecord());
+    expect(row[7]).toBe('NATIVE99'); // completion code column
+  });
+
+  it('sums native `submission_bonuses` into the Bonus column', () => {
+    const row = submissionToRow(makeNativeRecord());
+    expect(row[4]).toBe('£1.50'); // 100 + 50 minor = £1.50
+  });
+
+  it('preserves code + bonus when a native submission round-trips to CSV', () => {
+    const reimported = parseProlificCsv(submissionsToCsv([makeNativeRecord()]));
+    expect(reimported.records).toHaveLength(1);
+    const r = reimported.records[0];
+    // Re-imported as a csv: record, but the identity-bearing fields survive.
+    expect(r.study_name).toBe('Native Study');
+    expect(r.payload.completion_code).toBe('NATIVE99');
+    expect(r.payload.bonus_payments).toEqual([{ amount: 150, currency: 'GBP' }]);
+    expect(r.payload.submission_reward).toEqual({ amount: 500, currency: 'GBP' });
+  });
+
+  it('serialises a large batch without error', () => {
+    const many = Array.from({ length: 500 }, (_, i) =>
+      makeRecord({
+        submission_id: `csv:B${i}`,
+        study_name: `Study ${i}`,
+        payload: { ...makeRecord().payload, completion_code: `B${i}` },
+      }),
+    );
+    const csv = submissionsToCsv(many);
+    expect(csv.split('\r\n')).toHaveLength(501); // header + 500
+  });
+});
+
+// ── analytics serialisers ─────────────────────────────────────
+
+describe('analytics CSV serialisers', () => {
+  const rollups: DailyRollup[] = [
+    {
+      date_key: '2026-03-25',
+      reward_minor: 1234,
+      currency: 'USD',
+      submission_count: 3,
+      first_started_at: null,
+      last_completed_at: null,
+      active_span_seconds: 3600,
+      sum_duration_seconds: 1800,
+      hourly_active_major: 12.34,
+      hourly_focused_major: 24.68,
+    },
+  ];
+
+  it('serialises daily rollups with a header row', () => {
+    const parsed = parseCsv(dailyRollupsToCsv(rollups));
+    expect(parsed[0]).toContain('Date');
+    expect(parsed[1][0]).toBe('2026-03-25');
+    expect(parsed[1][3]).toBe('12.34'); // reward major
+  });
+
+  it('serialises group aggregates (researcher/study) with the given key header', () => {
+    const groups: GroupAgg[] = [
+      { key: 'r1', label: 'Dr Test', submission_count: 4, reward_minor: 2000, currency: 'GBP', hourly_rates: [10, 12, 14] },
+    ];
+    const parsed = parseCsv(groupAggToCsv(groups, 'Researcher'));
+    expect(parsed[0][0]).toBe('Researcher');
+    expect(parsed[1][0]).toBe('Dr Test');
+    expect(parsed[1][4]).toBe('20.00');
+    expect(parsed[1][5]).toBe('12'); // mean of 10,12,14
+  });
+
+  it('serialises a forecast', () => {
+    const parsed = parseCsv(forecastToCsv([{ date_key: '2026-07-05', median: 30, p25: 20, p75: 45 }], 'USD'));
+    expect(parsed[0]).toContain('Projected (median)');
+    expect(parsed[1]).toEqual(['2026-07-05', 'USD', '30', '20', '45']);
+  });
+
+  it('emits configurable JSON with only the requested sections', () => {
+    const json = analyticsToJson({ currency: 'USD', generated_at: '2026-07-04T00:00:00.000Z', daily: rollups });
+    const obj = JSON.parse(json);
+    expect(obj.currency).toBe('USD');
+    expect(obj.daily).toHaveLength(1);
+    expect(obj.researchers).toBeUndefined();
+    expect(obj.forecast).toBeUndefined();
+  });
+});
+
+// ── backup build / validate ───────────────────────────────────
+
+describe('buildBackup / validateBackup / summarizeBackup', () => {
+  const backup = buildBackup({
+    tables: { submissions: [{ submission_id: 'a' }, { submission_id: 'b' }], researchers: [] },
+    settings: { theme: 'dark', earningsPrefs: { primary_currency: 'USD' } },
+    dbVersion: 3,
+    appVersion: '1.3.1',
+    exportedAt: '2026-07-04T16:10:53.160Z',
+  });
+
+  it('stamps the format tag and metadata', () => {
+    expect(backup.format).toBe(BACKUP_FORMAT);
+    expect(backup.db_version).toBe(3);
+    expect(backup.app_version).toBe('1.3.1');
+  });
+
+  it('validates a well-formed backup (object or JSON string)', () => {
+    const fromObj = validateBackup(backup);
+    expect(fromObj.ok).toBe(true);
+    const fromStr = validateBackup(JSON.stringify(backup));
+    expect(fromStr.ok).toBe(true);
+  });
+
+  it('rejects malformed input without throwing', () => {
+    expect(validateBackup('not json{').ok).toBe(false);
+    expect(validateBackup(null).ok).toBe(false);
+    expect(validateBackup(42).ok).toBe(false);
+    expect(validateBackup({ format: 'something-else', tables: {} }).ok).toBe(false);
+    expect(validateBackup({ format: BACKUP_FORMAT }).ok).toBe(false); // no tables
+    expect(validateBackup({ format: BACKUP_FORMAT, tables: { submissions: 'nope' } }).ok).toBe(false);
+  });
+
+  it('defaults missing settings to an empty object', () => {
+    const res = validateBackup({ format: BACKUP_FORMAT, tables: { submissions: [] } });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.backup.settings).toEqual({});
+  });
+
+  it('summarises table counts sorted by size', () => {
+    const summary = summarizeBackup(backup);
+    expect(summary.tableTotal).toBe(2);
+    expect(summary.settingsCount).toBe(2);
+    expect(summary.tables[0]).toEqual({ name: 'submissions', count: 2 });
+  });
+});
+
+describe('backupDateStamp', () => {
+  it('formats a stable filename stamp', () => {
+    // Uses local time, so assert shape (TZ-independent) rather than exact date.
+    expect(backupDateStamp('2026-07-04T16:10:53.160Z')).toMatch(/^\d{4}-\d{2}-\d{2}-\d{4}$/);
+  });
+  it('falls back for bad input', () => {
+    expect(backupDateStamp('nope')).toBe('export');
+  });
+});

--- a/src/lib/__tests__/export-data.test.ts
+++ b/src/lib/__tests__/export-data.test.ts
@@ -17,6 +17,7 @@ import {
   BACKUP_FORMAT,
 } from '../export-data';
 import { parseCsv, parseMoneyCell, parseCsvTimestamp, parseProlificCsv } from '../import-csv';
+import { researcherRefFromPayload, extractSubmissionMeta, extractRejectionDetails } from '../submission-analytics';
 import type { SubmissionRecord } from '../db';
 import type { DailyRollup, GroupAgg } from '../earnings';
 
@@ -283,6 +284,67 @@ describe('submissionsToCsv round-trips through parseProlificCsv', () => {
     expect(r.payload.completion_code).toBe('NATIVE99');
     expect(r.payload.bonus_payments).toEqual([{ amount: 150, currency: 'GBP' }]);
     expect(r.payload.submission_reward).toEqual({ amount: 500, currency: 'GBP' });
+  });
+
+  // ── Enriched columns (researcher/institution/trial/rejection) round-trip ──
+  it('round-trips the extension-only fields Prolific CSV lacks', () => {
+    const native: SubmissionRecord = {
+      submission_id: 'sub-enriched',
+      study_id: 'study-xyz',
+      study_name: 'Enriched Study',
+      participant_id: 'p1',
+      status: 'REJECTED',
+      phase: 'submitted',
+      observed_at: '2026-05-01T10:20:00.000Z',
+      updated_at: '2026-05-01T10:20:00.000Z',
+      payload: {
+        study: {
+          name: 'Enriched Study',
+          is_trial_study: true,
+          researcher: { id: 'r-42', name: 'Dr Ada', country: 'GB', institution: { name: 'Somewhere Uni' } },
+        },
+        study_code: 'ENR123',
+        submission_reward: { amount: 400, currency: 'GBP' },
+        started_at: '2026-05-01T10:00:00.000Z',
+        returned_at: '2026-05-01T10:20:00.000Z',
+        return_reason: 'FAILED_ATTENTION_CHECK',
+        rejection_category: 'LOW_EFFORT',
+        rejection_message: 'Answers were inconsistent.',
+        researcher_message: 'Please read more carefully next time.',
+      },
+    };
+    const reimported = parseProlificCsv(submissionsToCsv([native])).records;
+    expect(reimported).toHaveLength(1);
+    const p = reimported[0].payload;
+
+    expect(researcherRefFromPayload(p)).toEqual({ id: 'r-42', name: 'Dr Ada', country: 'GB' });
+    const meta = extractSubmissionMeta(p);
+    expect(meta.institution_name).toBe('Somewhere Uni');
+    expect(meta.is_trial).toBe(true);
+    expect(p.completion_code).toBe('ENR123'); // code preserved (dedup key)
+
+    const rej = extractRejectionDetails(p);
+    expect(rej.return_reason).toBe('FAILED_ATTENTION_CHECK');
+    expect(rej.rejection_category).toBe('LOW_EFFORT');
+    expect(rej.rejection_message).toBe('Answers were inconsistent.');
+    expect(rej.researcher_message).toBe('Please read more carefully next time.');
+  });
+
+  it('still imports a stock Prolific CSV that has none of the enriched columns', () => {
+    const csv = [
+      'Study,Reward,Started at,Completed at,Completion code,Status',
+      'Plain Study,£3.00,2026-03-25 15:40:00.000000,2026-03-25 16:00:00.000000,PLAIN1,APPROVED',
+    ].join('\n');
+    const recs = parseProlificCsv(csv).records;
+    expect(recs).toHaveLength(1);
+    expect(researcherRefFromPayload(recs[0].payload)).toBeNull();
+  });
+
+  it('appends the enriched columns to the header', () => {
+    const header = submissionsToCsv([]).split('\r\n')[0].toLowerCase();
+    for (const col of ['researcher', 'researcher id', 'institution', 'trial', 'return reason', 'researcher feedback']) {
+      expect(header).toContain(col);
+    }
   });
 
   it('serialises a large batch without error', () => {

--- a/src/lib/__tests__/export-data.test.ts
+++ b/src/lib/__tests__/export-data.test.ts
@@ -317,6 +317,10 @@ describe('submissionsToCsv round-trips through parseProlificCsv', () => {
     expect(reimported).toHaveLength(1);
     const p = reimported[0].payload;
 
+    // Real study id round-trips on the record (links back to observed studies),
+    // not a csv: slug.
+    expect(reimported[0].study_id).toBe('study-xyz');
+
     expect(researcherRefFromPayload(p)).toEqual({ id: 'r-42', name: 'Dr Ada', country: 'GB' });
     const meta = extractSubmissionMeta(p);
     expect(meta.institution_name).toBe('Somewhere Uni');
@@ -338,11 +342,13 @@ describe('submissionsToCsv round-trips through parseProlificCsv', () => {
     const recs = parseProlificCsv(csv).records;
     expect(recs).toHaveLength(1);
     expect(researcherRefFromPayload(recs[0].payload)).toBeNull();
+    // No Study ID column → falls back to the csv: slug, as before.
+    expect(recs[0].study_id).toBe('csv:plain-study');
   });
 
   it('appends the enriched columns to the header', () => {
     const header = submissionsToCsv([]).split('\r\n')[0].toLowerCase();
-    for (const col of ['researcher', 'researcher id', 'institution', 'trial', 'return reason', 'researcher feedback']) {
+    for (const col of ['study id', 'researcher', 'researcher id', 'institution', 'trial', 'return reason', 'researcher feedback']) {
       expect(header).toContain(col);
     }
   });

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,0 +1,120 @@
+import { db } from './db';
+import { nowIso } from './format';
+import {
+  buildBackup,
+  type BackupFile,
+} from './export-data';
+
+// ──────────────────────────────────────────────────────────────
+// Backup / restore side-effects. Pure shaping + validation lives in
+// export-data.ts; this module owns the IndexedDB + storage I/O so it
+// stays thin and testable with fake-indexeddb.
+// ──────────────────────────────────────────────────────────────
+
+/** Minimal storage surface — lets tests inject an in-memory stand-in for browser.storage.local. */
+export interface BackupStorage {
+  getAll(): Promise<Record<string, unknown>>;
+  setAll(items: Record<string, unknown>): Promise<void>;
+}
+
+/** Dump every Dexie table into a `{ tableName: rows }` map. */
+export async function dumpTables(): Promise<Record<string, unknown[]>> {
+  const tables: Record<string, unknown[]> = {};
+  await db.transaction('r', db.tables, async () => {
+    for (const table of db.tables) {
+      tables[table.name] = await table.toArray();
+    }
+  });
+  return tables;
+}
+
+export interface ExportBackupOptions {
+  includeSettings?: boolean;
+}
+
+/** Build a full backup of the DB (+ optionally extension settings). */
+export async function exportBackup(
+  storage: BackupStorage,
+  appVersion: string,
+  opts: ExportBackupOptions = {},
+): Promise<BackupFile> {
+  const [tables, settings] = await Promise.all([
+    dumpTables(),
+    opts.includeSettings === false ? Promise.resolve({}) : storage.getAll(),
+  ]);
+  return buildBackup({
+    tables,
+    settings,
+    dbVersion: db.verno,
+    appVersion,
+    exportedAt: nowIso(),
+  });
+}
+
+export interface RestoreSummary {
+  tablesRestored: number;
+  rowsRestored: number;
+  settingsRestored: number;
+  skippedUnknownTables: string[];
+}
+
+export interface RestoreOptions {
+  /** Also overwrite browser.storage.local from the backup's settings. Default true. */
+  includeSettings?: boolean;
+}
+
+/**
+ * Restore a validated backup over the local DB (and optionally settings).
+ *
+ * Only tables the backup actually contains are cleared + repopulated, all inside
+ * one transaction (so a failure rolls the whole DB back). Tables NOT present in
+ * the backup are left untouched — restoring an older or partial backup must not
+ * silently wipe tables it doesn't know about. Unknown tables in the backup are
+ * skipped (reported) rather than failing.
+ *
+ * Settings are merged over `storage.local` (not cleared first): this preserves
+ * runtime-only keys such as the auth/`syncState` token so a restore doesn't sign
+ * the user out, and avoids a clear-then-fail window that would lose settings.
+ */
+export async function restoreBackup(
+  backup: BackupFile,
+  storage: BackupStorage,
+  opts: RestoreOptions = {},
+): Promise<RestoreSummary> {
+  const known = new Set(db.tables.map((t) => t.name));
+  const skippedUnknownTables = Object.keys(backup.tables).filter((name) => !known.has(name));
+
+  let tablesRestored = 0;
+  let rowsRestored = 0;
+  await db.transaction('rw', db.tables, async () => {
+    for (const table of db.tables) {
+      const rows = backup.tables[table.name];
+      if (!Array.isArray(rows)) continue; // table absent from backup → leave as-is
+      await table.clear();
+      if (rows.length > 0) {
+        await table.bulkPut(rows as readonly unknown[] as never[]);
+        rowsRestored += rows.length;
+      }
+      tablesRestored += 1;
+    }
+  });
+
+  let settingsRestored = 0;
+  if (opts.includeSettings !== false && backup.settings && Object.keys(backup.settings).length > 0) {
+    await storage.setAll(backup.settings);
+    settingsRestored = Object.keys(backup.settings).length;
+  }
+
+  return { tablesRestored, rowsRestored, settingsRestored, skippedUnknownTables };
+}
+
+/** Adapter over browser.storage.local for the real extension runtime. */
+export function browserStorageAdapter(storageLocal: {
+  get(keys?: null): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+}): BackupStorage {
+  return {
+    getAll: () => storageLocal.get(null),
+    setAll: (items) => storageLocal.set(items),
+  };
+}

--- a/src/lib/export-data.ts
+++ b/src/lib/export-data.ts
@@ -1,0 +1,349 @@
+import type { SubmissionRecord } from './db';
+import type { DailyRollup, GroupAgg } from './earnings';
+import { extractSubmissionReward, extractStartedAt, extractCompletedAt, mean } from './earnings';
+
+// ──────────────────────────────────────────────────────────────
+// CSV serialisation — inverse of import-csv's parseCsv.
+// ──────────────────────────────────────────────────────────────
+
+/** Quote a single CSV field if it contains a delimiter, quote, or newline. */
+export function csvField(value: unknown): string {
+  const s = value == null ? '' : String(value);
+  if (/[",\r\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Serialise rows into RFC-4180-ish CSV text (CRLF line endings, Excel-friendly). */
+export function toCsv(rows: (readonly unknown[])[]): string {
+  return rows.map((row) => row.map(csvField).join(',')).join('\r\n');
+}
+
+// ──────────────────────────────────────────────────────────────
+// Money / timestamp formatting — inverse of import-csv parsers, so
+// exported submissions round-trip cleanly back through parseProlificCsv.
+// ──────────────────────────────────────────────────────────────
+
+/**
+ * Currency → symbol for the unambiguous cases parseMoneyCell can read back to
+ * the exact same code. Ambiguous symbols (kr → SEK/NOK/DKK) are intentionally
+ * omitted so those fall through to the `amount CODE` form instead.
+ */
+const CURRENCY_TO_SYMBOL: Record<string, string> = {
+  GBP: '£',
+  EUR: '€',
+  USD: '$',
+  JPY: '¥',
+  INR: '₹',
+  RUB: '₽',
+  CAD: 'CA$',
+  AUD: 'A$',
+  NZD: 'NZ$',
+  HKD: 'HK$',
+  SGD: 'S$',
+  BRL: 'R$',
+  PLN: 'zł',
+};
+
+/** Format a minor-unit amount + currency into a cell parseMoneyCell reads back losslessly. */
+export function formatMoneyCell(amountMinor: number, currency: string): string {
+  const major = (Math.round(amountMinor) / 100).toFixed(2);
+  const code = String(currency || '').toUpperCase();
+  const symbol = CURRENCY_TO_SYMBOL[code];
+  if (symbol) return `${symbol}${major}`;
+  // Unknown or ambiguous currency: trailing 3-letter code (also parseable).
+  return code ? `${major} ${code}` : major;
+}
+
+/** `2026-03-25T16:10:53.160Z` → `2026-03-25 16:10:53.160000` (naive UTC, Prolific style). */
+export function formatCsvTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number, w = 2) => String(n).padStart(w, '0');
+  const date = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+  const time = `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
+  const micros = `${pad(d.getUTCMilliseconds(), 3)}000`;
+  return `${date} ${time}.${micros}`;
+}
+
+// ──────────────────────────────────────────────────────────────
+// Submissions → CSV (mirrors the columns parseProlificCsv reads).
+// ──────────────────────────────────────────────────────────────
+
+export const SUBMISSIONS_CSV_HEADER = [
+  'Submission id',
+  'Study',
+  'Status',
+  'Reward',
+  'Bonus',
+  'Started at',
+  'Completed at',
+  'Completion code',
+] as const;
+
+const RETURNED_LIKE = new Set(['RETURNED', 'REJECTED']);
+
+function payloadString(payload: Record<string, unknown>, key: string): string {
+  const v = payload[key];
+  return typeof v === 'string' ? v : '';
+}
+
+/**
+ * Completion code, reading both payload shapes: live-API submissions carry it as
+ * `study_code`, CSV-imported ones as `completion_code` (mirrors store.ts's
+ * cross-source dedup key). Without this a real user's live submissions would
+ * export a blank code and lose their identity on re-import.
+ */
+function extractCompletionCode(payload: Record<string, unknown>): string {
+  const raw = payload.completion_code ?? payload.study_code;
+  return typeof raw === 'string' ? raw.trim() : '';
+}
+
+/**
+ * Total bonus across all payments, again spanning both shapes: live-API uses
+ * `submission_bonuses`, CSV-imported uses `bonus_payments`. Prolific's own CSV
+ * shows a single summed Bonus column, so we sum rather than take the first.
+ */
+function extractBonusTotal(payload: Record<string, unknown>): { amount: number; currency: string } | null {
+  const list = Array.isArray(payload.bonus_payments)
+    ? payload.bonus_payments
+    : Array.isArray(payload.submission_bonuses)
+      ? payload.submission_bonuses
+      : [];
+  let amount = 0;
+  let currency = '';
+  for (const b of list) {
+    if (!b || typeof b !== 'object') continue;
+    const amt = Number((b as { amount?: unknown }).amount);
+    const cur = String((b as { currency?: unknown }).currency ?? '');
+    if (Number.isFinite(amt) && amt > 0) {
+      amount += amt;
+      if (!currency) currency = cur;
+    }
+  }
+  return amount > 0 && currency ? { amount, currency } : null;
+}
+
+/** Turn a stored submission into the [id, study, status, reward, bonus, started, completed, code] cells. */
+export function submissionToRow(record: SubmissionRecord): string[] {
+  const payload = (record.payload ?? {}) as Record<string, unknown>;
+  const reward = extractSubmissionReward(record);
+  const bonus = extractBonusTotal(payload);
+
+  const startedAt = extractStartedAt(record);
+  // The importer stashes the completion time under returned_at for RETURNED/REJECTED,
+  // so read it back from the same place to reconstruct the "Completed at" column.
+  const completedIso = RETURNED_LIKE.has(record.status)
+    ? payloadString(payload, 'returned_at') || payloadString(payload, 'completed_at')
+    : payloadString(payload, 'completed_at');
+  const completedAt = completedIso ? new Date(completedIso) : extractCompletedAt(record);
+
+  return [
+    record.submission_id,
+    record.study_name ?? '',
+    record.status ?? '',
+    reward ? formatMoneyCell(reward.amount, reward.currency) : '',
+    bonus ? formatMoneyCell(bonus.amount, bonus.currency) : '',
+    startedAt ? formatCsvTimestamp(startedAt.toISOString()) : '',
+    completedAt && !Number.isNaN(completedAt.getTime()) ? formatCsvTimestamp(completedAt.toISOString()) : '',
+    extractCompletionCode(payload),
+  ];
+}
+
+/** Serialise submissions to a Prolific-style CSV that round-trips through parseProlificCsv. */
+export function submissionsToCsv(records: SubmissionRecord[]): string {
+  const rows: (readonly unknown[])[] = [SUBMISSIONS_CSV_HEADER];
+  for (const r of records) rows.push(submissionToRow(r));
+  return toCsv(rows);
+}
+
+// ──────────────────────────────────────────────────────────────
+// Analytics → CSV (computed rollups/summaries the caller passes in).
+// ──────────────────────────────────────────────────────────────
+
+const money2 = (minor: number) => (Math.round(minor) / 100).toFixed(2);
+const round2 = (n: number) => (Number.isFinite(n) ? Math.round(n * 100) / 100 : 0);
+
+export function dailyRollupsToCsv(rollups: DailyRollup[]): string {
+  const rows: (readonly unknown[])[] = [
+    ['Date', 'Currency', 'Submissions', 'Reward', 'Active hours', 'Focused hours', 'Reward/hr (active)', 'Reward/hr (focused)'],
+  ];
+  for (const r of rollups) {
+    rows.push([
+      r.date_key,
+      r.currency,
+      r.submission_count,
+      money2(r.reward_minor),
+      round2(r.active_span_seconds / 3600),
+      round2(r.sum_duration_seconds / 3600),
+      round2(r.hourly_active_major),
+      round2(r.hourly_focused_major),
+    ]);
+  }
+  return toCsv(rows);
+}
+
+/** Researcher/study summaries share the GroupAgg shape. `keyHeader` labels the first column. */
+export function groupAggToCsv(rows: GroupAgg[], keyHeader: string): string {
+  const out: (readonly unknown[])[] = [
+    [keyHeader, 'Id', 'Currency', 'Submissions', 'Reward', 'Mean reward/hr'],
+  ];
+  for (const g of rows) {
+    out.push([g.label, g.key, g.currency, g.submission_count, money2(g.reward_minor), round2(mean(g.hourly_rates))]);
+  }
+  return toCsv(out);
+}
+
+export interface ForecastRow {
+  date_key: string;
+  median: number;
+  p25: number;
+  p75: number;
+}
+
+export function forecastToCsv(points: ForecastRow[], currency: string): string {
+  const rows: (readonly unknown[])[] = [['Date', 'Currency', 'Projected (median)', 'Low (p25)', 'High (p75)']];
+  for (const p of points) rows.push([p.date_key, currency, round2(p.median), round2(p.p25), round2(p.p75)]);
+  return toCsv(rows);
+}
+
+// Which analytics datasets can be exported. Drives the configurable UI.
+export type AnalyticsDatasetKey = 'daily' | 'researchers' | 'studies' | 'forecast';
+
+export interface AnalyticsBundle {
+  currency: string;
+  generated_at: string;
+  daily?: DailyRollup[];
+  researchers?: GroupAgg[];
+  studies?: GroupAgg[];
+  forecast?: ForecastRow[];
+}
+
+/** JSON form of the analytics export — includes only the sections present on the bundle. */
+export function analyticsToJson(bundle: AnalyticsBundle): string {
+  return JSON.stringify(bundle, dateReplacer, 2);
+}
+
+function dateReplacer(_key: string, value: unknown): unknown {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+// ──────────────────────────────────────────────────────────────
+// Full backup — all IndexedDB tables + extension settings.
+// ──────────────────────────────────────────────────────────────
+
+export const BACKUP_FORMAT = 'prolific-pulse-backup';
+
+export interface BackupFile {
+  format: typeof BACKUP_FORMAT;
+  /** Dexie DB version the backup was taken at (for forward-compat awareness). */
+  db_version: number;
+  app_version: string;
+  exported_at: string;
+  /** IndexedDB store name → rows. */
+  tables: Record<string, unknown[]>;
+  /** browser.storage.local snapshot (settings, prefs). */
+  settings: Record<string, unknown>;
+}
+
+export interface BackupParams {
+  tables: Record<string, unknown[]>;
+  settings: Record<string, unknown>;
+  dbVersion: number;
+  appVersion: string;
+  exportedAt: string;
+}
+
+export function buildBackup(params: BackupParams): BackupFile {
+  return {
+    format: BACKUP_FORMAT,
+    db_version: params.dbVersion,
+    app_version: params.appVersion,
+    exported_at: params.exportedAt,
+    tables: params.tables,
+    settings: params.settings,
+  };
+}
+
+export interface BackupSummaryRow {
+  name: string;
+  count: number;
+}
+
+export interface BackupSummary {
+  tables: BackupSummaryRow[];
+  tableTotal: number;
+  settingsCount: number;
+  exportedAt: string;
+}
+
+/** Human-facing summary of what a backup contains (drives the restore-confirm UI). */
+export function summarizeBackup(backup: BackupFile): BackupSummary {
+  const tables = Object.entries(backup.tables ?? {})
+    .map(([name, rows]) => ({ name, count: Array.isArray(rows) ? rows.length : 0 }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  return {
+    tables,
+    tableTotal: tables.reduce((sum, t) => sum + t.count, 0),
+    settingsCount: Object.keys(backup.settings ?? {}).length,
+    exportedAt: backup.exported_at ?? '',
+  };
+}
+
+export type BackupValidation =
+  | { ok: true; backup: BackupFile }
+  | { ok: false; error: string };
+
+/** Parse + shape-check untrusted backup JSON. Never throws. */
+export function validateBackup(raw: unknown): BackupValidation {
+  let obj = raw;
+  if (typeof raw === 'string') {
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      return { ok: false, error: "That file isn't valid JSON." };
+    }
+  }
+  if (!obj || typeof obj !== 'object') {
+    return { ok: false, error: "That file doesn't look like a Prolific Pulse backup." };
+  }
+  const b = obj as Record<string, unknown>;
+  if (b.format !== BACKUP_FORMAT) {
+    return { ok: false, error: "That file isn't a Prolific Pulse backup (wrong format tag)." };
+  }
+  if (!b.tables || typeof b.tables !== 'object' || Array.isArray(b.tables)) {
+    return { ok: false, error: 'This backup is missing its data tables.' };
+  }
+  for (const [name, rows] of Object.entries(b.tables as Record<string, unknown>)) {
+    if (!Array.isArray(rows)) {
+      return { ok: false, error: `Table "${name}" is corrupted (expected a list of rows).` };
+    }
+  }
+  const settings =
+    b.settings && typeof b.settings === 'object' && !Array.isArray(b.settings)
+      ? (b.settings as Record<string, unknown>)
+      : {};
+  return {
+    ok: true,
+    backup: {
+      format: BACKUP_FORMAT,
+      db_version: Number(b.db_version) || 0,
+      app_version: typeof b.app_version === 'string' ? b.app_version : '',
+      exported_at: typeof b.exported_at === 'string' ? b.exported_at : '',
+      tables: b.tables as Record<string, unknown[]>,
+      settings,
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────
+// Filename helpers.
+// ──────────────────────────────────────────────────────────────
+
+/** `2026-07-04T16:10:53.160Z` → `2026-07-04-1610`. Falls back to date-only on bad input. */
+export function backupDateStamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'export';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}`;
+}

--- a/src/lib/export-data.ts
+++ b/src/lib/export-data.ts
@@ -83,6 +83,7 @@ export const SUBMISSIONS_CSV_HEADER = [
   'Completion code',
   // Extension-only columns Prolific's own export lacks. The importer reads these
   // back when present, and ignores them on a stock Prolific CSV.
+  'Study ID',
   'Researcher',
   'Researcher ID',
   'Researcher country',
@@ -165,6 +166,7 @@ export function submissionToRow(record: SubmissionRecord): string[] {
     extractCompletionCode(payload),
     // Extension-only fields (missing from Prolific's CSV), via the same
     // extractors the analytics use so both payload shapes are handled.
+    record.study_id,
     researcher?.name ?? '',
     researcher?.id ?? '',
     researcher?.country ?? meta.researcher_country ?? '',

--- a/src/lib/export-data.ts
+++ b/src/lib/export-data.ts
@@ -1,6 +1,7 @@
 import type { SubmissionRecord } from './db';
 import type { DailyRollup, GroupAgg } from './earnings';
 import { extractSubmissionReward, extractStartedAt, extractCompletedAt, mean } from './earnings';
+import { researcherRefFromPayload, extractSubmissionMeta, extractRejectionDetails } from './submission-analytics';
 
 // ──────────────────────────────────────────────────────────────
 // CSV serialisation — inverse of import-csv's parseCsv.
@@ -71,6 +72,7 @@ export function formatCsvTimestamp(iso: string | null | undefined): string {
 // ──────────────────────────────────────────────────────────────
 
 export const SUBMISSIONS_CSV_HEADER = [
+  // Prolific-format columns (round-trip through the stock importer).
   'Submission id',
   'Study',
   'Status',
@@ -79,6 +81,17 @@ export const SUBMISSIONS_CSV_HEADER = [
   'Started at',
   'Completed at',
   'Completion code',
+  // Extension-only columns Prolific's own export lacks. The importer reads these
+  // back when present, and ignores them on a stock Prolific CSV.
+  'Researcher',
+  'Researcher ID',
+  'Researcher country',
+  'Institution',
+  'Trial',
+  'Return reason',
+  'Rejection category',
+  'Rejection message',
+  'Researcher feedback',
 ] as const;
 
 const RETURNED_LIKE = new Set(['RETURNED', 'REJECTED']);
@@ -129,6 +142,9 @@ export function submissionToRow(record: SubmissionRecord): string[] {
   const payload = (record.payload ?? {}) as Record<string, unknown>;
   const reward = extractSubmissionReward(record);
   const bonus = extractBonusTotal(payload);
+  const researcher = researcherRefFromPayload(payload);
+  const meta = extractSubmissionMeta(payload);
+  const rejection = extractRejectionDetails(payload);
 
   const startedAt = extractStartedAt(record);
   // The importer stashes the completion time under returned_at for RETURNED/REJECTED,
@@ -147,6 +163,17 @@ export function submissionToRow(record: SubmissionRecord): string[] {
     startedAt ? formatCsvTimestamp(startedAt.toISOString()) : '',
     completedAt && !Number.isNaN(completedAt.getTime()) ? formatCsvTimestamp(completedAt.toISOString()) : '',
     extractCompletionCode(payload),
+    // Extension-only fields (missing from Prolific's CSV), via the same
+    // extractors the analytics use so both payload shapes are handled.
+    researcher?.name ?? '',
+    researcher?.id ?? '',
+    researcher?.country ?? meta.researcher_country ?? '',
+    meta.institution_name ?? '',
+    meta.is_trial ? 'yes' : '',
+    rejection.return_reason ?? '',
+    rejection.rejection_category ?? '',
+    rejection.rejection_message ?? '',
+    rejection.researcher_message ?? '',
   ];
 }
 

--- a/src/lib/import-csv.ts
+++ b/src/lib/import-csv.ts
@@ -133,6 +133,7 @@ export function parseProlificCsv(text: string): CsvImportResult {
     status: header.indexOf('status'),
     // Enriched columns Prolific Pulse adds on export (all optional — a stock
     // Prolific CSV simply won't have them, so these stay -1 and are skipped).
+    studyId: header.indexOf('study id'),
     researcher: header.indexOf('researcher'),
     researcherId: header.indexOf('researcher id'),
     researcherCountry: header.indexOf('researcher country'),
@@ -182,6 +183,10 @@ export function parseProlificCsv(text: string): CsvImportResult {
     // Reconstruct the extension-only fields (researcher/institution/trial) that
     // Prolific's own CSV lacks, so an enriched export round-trips them back into
     // the same payload shape the analytics read (study.researcher, is_trial_study).
+    // Real Prolific study id (enriched export only) — set on the record so a
+    // re-imported row links back to observed studies (by-study-type breakdown,
+    // per-study grouping key off the record's study_id, not payload.study.id).
+    const realStudyId = cell(idx.studyId);
     const study: Record<string, unknown> = { name: studyName };
     const researcherId = cell(idx.researcherId);
     const researcherName = cell(idx.researcher);
@@ -231,7 +236,7 @@ export function parseProlificCsv(text: string): CsvImportResult {
 
     out.push({
       submission_id: submissionId,
-      study_id: `${CSV_SUBMISSION_ID_PREFIX}${slugify(studyName)}`,
+      study_id: realStudyId || `${CSV_SUBMISSION_ID_PREFIX}${slugify(studyName)}`,
       study_name: studyName,
       participant_id: CSV_IMPORT_SOURCE,
       status,

--- a/src/lib/import-csv.ts
+++ b/src/lib/import-csv.ts
@@ -131,6 +131,17 @@ export function parseProlificCsv(text: string): CsvImportResult {
     completedAt: header.indexOf('completed at'),
     code: header.indexOf('completion code'),
     status: header.indexOf('status'),
+    // Enriched columns Prolific Pulse adds on export (all optional — a stock
+    // Prolific CSV simply won't have them, so these stay -1 and are skipped).
+    researcher: header.indexOf('researcher'),
+    researcherId: header.indexOf('researcher id'),
+    researcherCountry: header.indexOf('researcher country'),
+    institution: header.indexOf('institution'),
+    trial: header.indexOf('trial'),
+    returnReason: header.indexOf('return reason'),
+    rejectionCategory: header.indexOf('rejection category'),
+    rejectionMessage: header.indexOf('rejection message'),
+    researcherFeedback: header.indexOf('researcher feedback'),
   };
   if (idx.study < 0 || idx.reward < 0 || idx.status < 0) {
     return {
@@ -166,10 +177,38 @@ export function parseProlificCsv(text: string): CsvImportResult {
       continue;
     }
 
+    const cell = (i: number) => (i >= 0 ? (row[i] ?? '').trim() : '');
+
+    // Reconstruct the extension-only fields (researcher/institution/trial) that
+    // Prolific's own CSV lacks, so an enriched export round-trips them back into
+    // the same payload shape the analytics read (study.researcher, is_trial_study).
+    const study: Record<string, unknown> = { name: studyName };
+    const researcherId = cell(idx.researcherId);
+    const researcherName = cell(idx.researcher);
+    const researcherCountry = cell(idx.researcherCountry);
+    const institution = cell(idx.institution);
+    if (researcherId || researcherName || researcherCountry || institution) {
+      const researcher: Record<string, unknown> = {};
+      if (researcherId) researcher.id = researcherId;
+      if (researcherName) researcher.name = researcherName;
+      if (researcherCountry) researcher.country = researcherCountry;
+      if (institution) researcher.institution = { name: institution };
+      study.researcher = researcher;
+    }
+    if (/^(yes|true|1)$/i.test(cell(idx.trial))) study.is_trial_study = true;
+
     const payload: Record<string, unknown> = {
-      study: { name: studyName },
+      study,
       _source: CSV_IMPORT_SOURCE,
     };
+    const returnReason = cell(idx.returnReason);
+    const rejectionCategory = cell(idx.rejectionCategory);
+    const rejectionMessage = cell(idx.rejectionMessage);
+    const researcherFeedback = cell(idx.researcherFeedback);
+    if (returnReason) payload.return_reason = returnReason;
+    if (rejectionCategory) payload.rejection_category = rejectionCategory;
+    if (rejectionMessage) payload.rejection_message = rejectionMessage;
+    if (researcherFeedback) payload.researcher_message = researcherFeedback;
     if (reward) payload.submission_reward = { amount: reward.amount_minor, currency: reward.currency };
     if (bonus && bonus.amount_minor > 0) {
       payload.bonus_payments = [{ amount: bonus.amount_minor, currency: bonus.currency }];

--- a/tests-wdio/specs/15-export-backup.js
+++ b/tests-wdio/specs/15-export-backup.js
@@ -1,0 +1,207 @@
+// E2E for the data export & backup feature (issue #23), on the full-page app.
+// Dev build, no login. Drives the real UI (backup button, analytics panel,
+// restore confirm) AND performs a genuine export → wipe → restore round-trip
+// through __ppDev, which calls the shipped backup lib against real IndexedDB
+// and real browser.storage.local. Runs under wdio.visual.conf.js.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { POPUP_URL } from '../helpers/constants.js';
+
+import { fileURLToPath } from 'node:url';
+
+const APP_URL = POPUP_URL.replace('/popup.html', '/app.html');
+const OUT_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'screenshots', 'visual');
+
+async function waitForDev() {
+  await browser.waitUntil(
+    async () => browser.execute(() => typeof window.__ppDev?.exportBackup === 'function'),
+    { timeout: 10_000, timeoutMsg: '__ppDev.exportBackup not available' },
+  );
+}
+
+async function openApp() {
+  await browser.url(APP_URL);
+  await waitForDev();
+}
+
+async function wipeAll() {
+  await browser.executeAsync((done) => {
+    (async () => {
+      await window.__ppDev.clear().catch(() => {});
+      await window.__ppDev.wipeStudyData().catch(() => {});
+      done(true);
+    })().catch(() => done(true));
+  });
+}
+
+async function seedData(subs, researchers) {
+  const result = await browser.executeAsync((s, r, done) => {
+    (async () => {
+      await window.__ppDev.clear().catch(() => {});
+      await window.__ppDev.wipeStudyData().catch(() => {});
+      await window.__ppDev.seed(s);
+      await window.__ppDev.seedResearchers(r);
+      done(await window.__ppDev.countTables());
+    })().catch((e) => done({ error: String(e) }));
+  }, subs, researchers);
+  if (result.error) throw new Error(`seedData failed: ${result.error}`);
+  return result;
+}
+
+describe('Data export & backup (issue #23)', () => {
+  before(async () => {
+    await browser.url(APP_URL);
+    await waitForDev();
+    try { await browser.setWindowRect(0, 0, 1280, 2000); } catch { /* ignore */ }
+  });
+
+  describe('UI presence', () => {
+    it('shows the Backup & export card even with an empty database', async () => {
+      await wipeAll();
+      await openApp();
+      const card = await $('#dataExportCard');
+      await card.waitForExist({ timeout: 8000 });
+      expect(await card.isDisplayed()).toBe(true);
+
+      // Export buttons disabled with no submissions; backup/restore always available.
+      expect(await $('#exportSubmissionsBtn').isEnabled()).toBe(false);
+      expect(await $('#exportAnalyticsBtn').isEnabled()).toBe(false);
+      expect(await $('#backupAllBtn').isEnabled()).toBe(true);
+      expect(await $('#restoreBtn').isEnabled()).toBe(true);
+    });
+
+    it('enables the export buttons once there are submissions', async () => {
+      await seedData(40, 5);
+      await openApp();
+      await $('#dataExportCard').waitForExist({ timeout: 8000 });
+      await browser.waitUntil(async () => $('#exportSubmissionsBtn').isEnabled(), {
+        timeout: 8000,
+        timeoutMsg: 'export submissions button never enabled',
+      });
+      expect(await $('#exportAnalyticsBtn').isEnabled()).toBe(true);
+    });
+  });
+
+  describe('Backup button', () => {
+    it('runs a real backup and reports a success banner', async () => {
+      await seedData(40, 5);
+      await openApp();
+      await $('#backupAllBtn').waitForClickable({ timeout: 8000 });
+      await $('#backupAllBtn').click();
+      const banner = await $('#exportBanner');
+      await banner.waitForExist({ timeout: 8000 });
+      const text = await banner.getText();
+      expect(text).toContain('Backed up');
+      expect(text).toMatch(/\d+ records?/);
+    });
+  });
+
+  describe('Analytics export panel', () => {
+    it('toggles open and gates the download button on a selection', async () => {
+      await seedData(60, 4);
+      await openApp();
+      await $('#exportAnalyticsBtn').waitForClickable({ timeout: 8000 });
+      await $('#exportAnalyticsBtn').click();
+      await $('#analyticsExportPanel').waitForExist({ timeout: 4000 });
+      expect(await $('#analyticsDownloadBtn').isEnabled()).toBe(true);
+
+      // Visual artifact: the card + open analytics panel, light & dark.
+      fs.mkdirSync(OUT_DIR, { recursive: true });
+      await $('#dataExportCard').scrollIntoView();
+      await browser.pause(200);
+      await browser.execute(() => document.documentElement.setAttribute('data-theme', 'light'));
+      await browser.pause(150);
+      await browser.saveScreenshot(path.join(OUT_DIR, 'export-card-light.png'));
+      await browser.execute(() => document.documentElement.setAttribute('data-theme', 'dark'));
+      await browser.pause(150);
+      await browser.saveScreenshot(path.join(OUT_DIR, 'export-card-dark.png'));
+
+      // Deselect every dataset → download disabled.
+      const boxes = await $$('#analyticsExportPanel input[type="checkbox"]');
+      for (const box of boxes) {
+        if (await box.isSelected()) await box.click();
+      }
+      await browser.waitUntil(async () => !(await $('#analyticsDownloadBtn').isEnabled()), {
+        timeout: 4000,
+        timeoutMsg: 'download button did not disable when nothing selected',
+      });
+    });
+  });
+
+  describe('Export → wipe → restore round-trip (real lib, real IndexedDB)', () => {
+    it('restores every table to its original counts', async () => {
+      const before = await seedData(50, 6);
+      await openApp();
+
+      const result = await browser.executeAsync((done) => {
+        (async () => {
+          const json = await window.__ppDev.exportBackup();
+          await window.__ppDev.clear();
+          await window.__ppDev.wipeStudyData();
+          const afterWipe = await window.__ppDev.countTables();
+          const summary = await window.__ppDev.restoreBackup(json);
+          const afterRestore = await window.__ppDev.countTables();
+          done({ jsonLen: json.length, afterWipe, summary, afterRestore });
+        })().catch((e) => done({ error: String(e) }));
+      });
+      if (result.error) throw new Error(result.error);
+
+      expect(result.jsonLen).toBeGreaterThan(0);
+      expect(result.afterWipe.submissions).toBe(0);
+      expect(result.afterRestore.submissions).toBe(before.submissions);
+      expect(result.afterRestore.researchers).toBe(before.researchers);
+      expect(result.summary.rowsRestored).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Restore via the file picker (real UI)', () => {
+    it('opens a confirm dialog from an uploaded backup and applies it', async () => {
+      const before = await seedData(30, 3);
+      await openApp();
+
+      // Grab a real backup string and write it to a temp file for the <input type=file>.
+      const exported = await browser.executeAsync((done) => {
+        window.__ppDev.exportBackup().then((j) => done({ json: j })).catch((e) => done({ error: String(e) }));
+      });
+      if (exported.error) throw new Error(exported.error);
+      const tmp = path.join(os.tmpdir(), `pp-backup-${Date.now()}.json`);
+      fs.writeFileSync(tmp, exported.json, 'utf8');
+
+      await wipeAll();
+
+      // geckodriver won't fire `change` on a display:none input, so un-hide the
+      // (still off-screen) file input just for the upload. Product code is unchanged.
+      await browser.execute(() => {
+        const inp = document.querySelector('#dataExportCard input[type="file"]');
+        if (inp) inp.classList.remove('hidden');
+      });
+      const fileInput = await $('#dataExportCard input[type="file"]');
+      await fileInput.addValue(tmp);
+
+      // The confirm dialog (and its confirm button) only exist once the file parses,
+      // so a clickable #confirmRestoreBtn proves the confirm UI rendered. (getText is
+      // avoided here — geckodriver returns "" for off-viewport innerText.)
+      const confirmBtn = await $('#confirmRestoreBtn');
+      await confirmBtn.waitForClickable({ timeout: 8000 });
+      expect(await $('#restoreConfirm').isExisting()).toBe(true);
+
+      await confirmBtn.click();
+      const banner = await $('#exportBanner');
+      await banner.waitForExist({ timeout: 8000 });
+      await banner.scrollIntoView();
+      await browser.waitUntil(async () => (await banner.getText()).includes('Restored'), {
+        timeout: 8000,
+        timeoutMsg: 'restore success banner never showed',
+      });
+
+      const after = await browser.executeAsync((done) => {
+        window.__ppDev.countTables().then((c) => done(c)).catch((e) => done({ error: String(e) }));
+      });
+      expect(after.submissions).toBe(before.submissions);
+
+      try { fs.unlinkSync(tmp); } catch { /* ignore */ }
+    });
+  });
+});

--- a/tests-wdio/wdio.visual.conf.js
+++ b/tests-wdio/wdio.visual.conf.js
@@ -38,6 +38,7 @@ export const config = {
     path.resolve('./specs/12-resilience-status.js'),
     path.resolve('./specs/13-mutes-assertions.js'),
     path.resolve('./specs/14-pause-assertions.js'),
+    path.resolve('./specs/15-export-backup.js'),
   ],
 
   capabilities: [{


### PR DESCRIPTION
Closes #23.

Adds a **Backup & export** section to the app dashboard (next to Import CSV):

- **Submissions → CSV** — Prolific-compatible, and a *superset*: also carries the fields Prolific's own export omits but the extension tracks and uses — study id, researcher (id/name/country), institution, trial flag, and return/rejection details. Round-trips through the importer; a stock Prolific CSV still imports unchanged.
- **Analytics → CSV/JSON** — configurable (daily totals / by researcher / by study / forecast, CSV or JSON).
- **Full backup → JSON** — all IndexedDB tables + settings; **Restore** validates the file, shows what's inside, confirms, then restores. Restore only touches tables the backup contains and merges settings (preserves the auth token — can't sign you out).

Also guards the popup/app entry mounts to their own page (fixes the popup double-mounting onto app.html when Vite hoists a shared chunk).

**Verified:** 681 unit tests (CSV round-trips incl. native+CSV payload shapes, backup validate/restore, malformed-input rejection); FF + Chrome builds; e2e `15-export-backup.js` (6 tests — export, analytics gating, real export→wipe→restore round-trip, file-picker restore); popup specs 11/13/14 still green.