### PR TITLE
Fix researcher modal expanding the popup height

### DIFF
--- a/src/entrypoints/popup/App.svelte
+++ b/src/entrypoints/popup/App.svelte
@@ -906,10 +906,12 @@
   });
 </script>
 
-<!-- While the researcher card is open, grow the popup to a consistent height (toward the browser's
-     ~600px popup cap) so the modal has the same room regardless of which tab is behind it — otherwise
-     its max-height tracks each tab's differing content height and scrolls by different amounts. -->
-<main class="w-[620px] p-3 bg-base-200 text-base-content" style:min-height={researcherProfile ? '600px' : undefined}>
+<!-- The researcher card overlays this wrapper (absolute inset-0), so it's sized by the wrapper's
+     definite height (the current popup height) rather than the popup's ambiguous 100vh. A fixed/100vh
+     overlay feeds back into the browser's content-based popup sizing and grows the popup on open; this
+     overlays in place and scrolls the card internally instead. -->
+<div class="relative w-[620px]">
+<main class="w-[620px] p-3 bg-base-200 text-base-content">
   <StatusBar
     offline={!!errorMessage}
     {errorMessage}
@@ -1035,6 +1037,8 @@
     <div id="panelSettings" class="panel" class:active={activeTab === 'settings'}></div>
   {/if}
 
+</main>
+
   <ResearcherProfileCard
     profile={researcherProfile}
     latestStudy={profileLatestStudy}
@@ -1043,4 +1047,4 @@
     onPrioritize={() => addResearcherFromProfile('match')}
     onBlacklist={() => addResearcherFromProfile('ignore')}
   />
-</main>
+</div>

--- a/src/entrypoints/popup/components/ResearcherProfileCard.svelte
+++ b/src/entrypoints/popup/components/ResearcherProfileCard.svelte
@@ -115,10 +115,10 @@
 {#if profile}
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <div
-    class="researcher-profile-card fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-2"
+    class="researcher-profile-card absolute inset-0 bg-black/40 z-50 flex items-center justify-center p-2"
     onclick={handleBackdropClick}
   >
-    <div class="bg-base-100 w-full max-w-md rounded-2xl shadow-xl max-h-[calc(100vh-1rem)] overflow-y-auto">
+    <div class="bg-base-100 w-full max-w-md rounded-2xl shadow-xl max-h-[calc(100%-1rem)] overflow-y-auto">
       <div class="sticky top-0 bg-base-100 px-4 pt-4 pb-2 border-b border-base-300 flex items-start justify-between gap-2">
         <div class="flex-1 min-w-0">
           <h3 class="text-sm font-semibold text-base-content line-clamp-2">{profile.name}</h3>


### PR DESCRIPTION
Opening the researcher profile modal expanded the extension popup's height (and could overshoot) instead of overlaying in place.

**Cause** (from f43253c, not the #23 export work): the modal used `position: fixed` + `max-h-[calc(100vh-1rem)]`, and `<main>` got `min-height:600px` while open. A browser popup auto-sizes to its content, so a `fixed`/`100vh` overlay feeds back into that sizing and grows the popup.

**Fix:** anchor the modal to a `relative` wrapper via `absolute inset-0` and cap the card at `max-h-[calc(100%-1rem)]` (a definite-height parent, no `100vh`). The modal now overlays the popup at its current height and scrolls the card internally, with no resize. Dropped the `min-height:600px` growth.

Verified: 681 unit tests; FF + Chrome builds; popup e2e (visual-researcher opens the modal — renders centered with internal scroll; earnings/mutes/pause assertions 32/32).

Note: the e2e harness loads `popup.html` as a full-size tab, so it can't reproduce the constrained-popup sizing — verified by reasoning + the visual render.